### PR TITLE
Add Home URL and Source Code URL

### DIFF
--- a/src/agent.yml
+++ b/src/agent.yml
@@ -10,7 +10,8 @@ description: |
     (PHP, Python...), before sending it to Blackfire.io servers so that you can display and analyze it.
 
 display:
-    home_url: https://github.com/blackfireio/integration-circleci
+    home_url: https://blackfire.io/
+    source_url: https://github.com/blackfireio/integration-circleci
 
 commands:
     register:

--- a/src/php.yml
+++ b/src/php.yml
@@ -10,7 +10,8 @@ description: |
     Its wide variety of automation options makes it a breathe to add it to a development and testing workflow.
 
 display:
-    home_url: https://github.com/blackfireio/integration-circleci
+    home_url: https://blackfire.io/
+    source_url: https://github.com/blackfireio/integration-circleci
 
 orbs:
     blackfire-agent: blackfireio/agent@1.0


### PR DESCRIPTION
Display a link to your home page and the orb source natively in the Orb registry as a clickable link.